### PR TITLE
Fixed typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Enter the repos and install.
     cd pyzfscmds
     python setup.py install
 
-    cd ../zedenv pyzfscmds
+    cd ../zedenv
     python setup.py install
 
 Makefile


### PR DESCRIPTION
The pyzfscmds in the instructions to install zedenv ("cd ../zedenv pyzfscmds") appears to be a typo.