### PR TITLE
Add 'get' and 'set' commands

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,11 +17,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../'))
-
 from zedenv import __version__
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 pep8maxlinelength = 99
+pep8ignore =
+    *.py E701
+    doc/source/conf.py E402

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dev_require = [
 ]
 
 dependency_links = [
-     'git+https://github.com/johnramsden/pyzfscmds#egg=pyzfscmds'
+    'git+https://github.com/johnramsden/pyzfscmds#egg=pyzfscmds'
 ]
 
 
@@ -36,9 +36,9 @@ setup(
     author_email='johnramsden@riseup.net',
     license='BSD-3-Clause',
     classifiers=[
-      'Development Status :: 3 - Alpha',
-      'License :: OSI Approved :: BSD License',
-      'Programming Language :: Python :: 3.6',
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='cli',
     packages=find_packages(exclude=["*tests*", "test_*"]),

--- a/tests/cli/test_destroy.py
+++ b/tests/cli/test_destroy.py
@@ -1,14 +1,12 @@
 """Test zedenv create command"""
 
 import datetime
-
 import pytest
 import pyzfscmds.utility as zfs_utility
-
-import zedenv.cli.destroy
-import zedenv.cli.create
-import zedenv.lib.check
 import zedenv.cli.activate
+import zedenv.cli.create
+import zedenv.cli.destroy
+import zedenv.lib.check
 
 require_root_dataset = pytest.mark.require_root_dataset
 require_unsafe = pytest.mark.require_unsafe
@@ -68,12 +66,13 @@ def test_boot_environment_destroy_fails(root_dataset, created_boot_environment):
     bootloader = None
 
     zedenv.cli.activate.zedenv_activate(created_boot_environment,
-                                        parent_dataset,  verbose, bootloader, noconfirm, noop)
+                                        parent_dataset, verbose, bootloader, noconfirm, noop)
 
     with pytest.raises(SystemExit):
         zedenv.cli.destroy.zedenv_destroy(created_boot_environment,
                                           parent_dataset,
                                           root_dataset,
+                                          bootloader,
                                           verbose,
                                           noconfirm,
                                           noop)

--- a/zedenv/__init__.py
+++ b/zedenv/__init__.py
@@ -11,8 +11,8 @@ def vcs_release(version: str):
     """
     try:
         git_hash = subprocess.check_output(
-                        ['git', 'rev-parse', '--short', 'HEAD'],
-                        universal_newlines=True, stderr=subprocess.PIPE)
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            universal_newlines=True, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
         return version
 
@@ -26,8 +26,8 @@ def get_release_version(version: str):
     has_tags = None
     try:
         has_tags = subprocess.check_output(
-                                    ['git', 'tag', '-l', '--points-at', 'HEAD'],
-                                    universal_newlines=True, stderr=subprocess.PIPE)
+            ['git', 'tag', '-l', '--points-at', 'HEAD'],
+            universal_newlines=True, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
         pass
 

--- a/zedenv/cli/get.py
+++ b/zedenv/cli/get.py
@@ -1,4 +1,6 @@
-"""Get boot environment properties cli"""
+"""
+Set boot environment properties cli
+"""
 
 import click
 import pyzfscmds.cmd
@@ -143,7 +145,7 @@ def zedenv_get(zedenv_properties: Optional[list],
 
 
 @click.command(name="get",
-               help="Get all boot environment properties that are set.")
+               help="Print boot environment properties.")
 @click.option('--recursive', '-r',
               is_flag=True,
               help="Recursively get all zedenv properties from all datasets under ROOT.")

--- a/zedenv/cli/get.py
+++ b/zedenv/cli/get.py
@@ -1,15 +1,12 @@
 """Get boot environment properties cli"""
 
-from typing import Optional, List
-
 import click
-
-import pyzfscmds.system.agnostic
 import pyzfscmds.cmd
-
+import pyzfscmds.system.agnostic
 import zedenv.configuration
 import zedenv.lib.be
 import zedenv.lib.check
+from typing import Optional, List
 from zedenv.lib.logger import ZELogger
 
 
@@ -22,7 +19,7 @@ def format_get(get_line: list,
     if scripting:
         return "\t".join(get_line)
     else:
-        fmt_line = ["{{: <{width}}}".format(width=w+1) for w in widths]
+        fmt_line = ["{{: <{width}}}".format(width=(w + 1)) for w in widths]
         return " ".join(fmt_line).format(*get_line)
 
 
@@ -30,7 +27,6 @@ def zedenv_get(zedenv_properties: Optional[list],
                scripting: Optional[bool],
                recursive: Optional[bool],
                be_root: str):
-
     property_index = 0
     columns = ["property", "value"]
 
@@ -106,7 +102,6 @@ def zedenv_get(zedenv_properties: Optional[list],
 def cli(zedenv_properties: Optional[list],
         scripting: Optional[bool],
         recursive: Optional[bool]):
-
     try:
         zedenv.lib.check.startup_check()
     except RuntimeError as err:

--- a/zedenv/cli/get.py
+++ b/zedenv/cli/get.py
@@ -1,0 +1,75 @@
+"""Get boot environment properties cli"""
+
+from typing import Optional
+
+import click
+
+import pyzfscmds.system.agnostic
+import pyzfscmds.cmd
+
+import zedenv.lib.be
+import zedenv.lib.check
+from zedenv.lib.logger import ZELogger
+
+
+def zedenv_get(zedenv_properties: Optional[list],
+               scripting: Optional[bool],
+               recursive: Optional[bool],
+               be_root: str):
+
+    property_index = 0
+    columns = ["property", "value"]
+
+    zedenv_props = zedenv_properties if zedenv_properties else ["all"]
+
+    if recursive:
+        property_index = property_index + 1
+        columns.insert(0, "name")
+
+    props = None
+    try:
+        props = pyzfscmds.cmd.zfs_get(be_root,
+                                      properties=zedenv_props,
+                                      scripting=scripting,
+                                      recursive=recursive,
+                                      columns=columns,
+                                      zfs_types=['filesystem'])
+    except RuntimeError as err:
+        ZELogger.log({
+            "level": "EXCEPTION",
+            "message": f"Failed to get zedenv properties\n{err}\n"
+        }, exit_on_error=True)
+
+    prop_list = props.splitlines()
+
+    if not scripting:
+        ZELogger.log({"level": "INFO", "message": prop_list[0]})
+
+    for p in prop_list:
+        split_prop = p.split()
+        if split_prop[property_index].startswith("org.zedenv"):
+            ZELogger.log({"level": "INFO", "message": p})
+
+
+@click.command(name="get",
+               help="Get all boot environment properties that are set.")
+@click.option('--recursive', '-r',
+              is_flag=True,
+              help="Recursively get all zedenv properties from all datasets under ROOT.")
+@click.option('--scripting', '-H',
+              is_flag=True,
+              help="Scripting output.")
+@click.argument('zedenv_properties', nargs=-1, required=False)
+def cli(zedenv_properties: Optional[list],
+        scripting: Optional[bool],
+        recursive: Optional[bool]):
+
+    try:
+        zedenv.lib.check.startup_check()
+    except RuntimeError as err:
+        ZELogger.log({"level": "EXCEPTION", "message": err}, exit_on_error=True)
+
+    zedenv_get(zedenv_properties,
+               scripting,
+               recursive,
+               zedenv.lib.be.root())

--- a/zedenv/cli/list.py
+++ b/zedenv/cli/list.py
@@ -1,15 +1,11 @@
 """List boot environments cli"""
 
-import sys
-from typing import Optional, List
-
 import click
-
-import pyzfscmds.utility as zfs_utility
 import pyzfscmds.system.agnostic
-
+import pyzfscmds.utility as zfs_utility
 import zedenv.lib.be
 import zedenv.lib.check
+from typing import Optional, List
 from zedenv.lib.logger import ZELogger
 
 
@@ -22,7 +18,7 @@ def format_boot_environment(be_list_line: list,
     if scripting:
         return "\t".join(be_list_line)
     else:
-        fmt_line = ["{{: <{width}}}".format(width=w+1) for w in widths]
+        fmt_line = ["{{: <{width}}}".format(width=(w + 1)) for w in widths]
         return " ".join(fmt_line).format(*be_list_line)
 
 

--- a/zedenv/cli/list.py
+++ b/zedenv/cli/list.py
@@ -143,7 +143,7 @@ def zedenv_list(verbose: Optional[bool],
     boot_environments = configure_boot_environment_list(be_root, columns, scripting)
 
     for list_output in boot_environments:
-        ZELogger.log({"level": "INFO", "message": list_output}, verbose)
+        ZELogger.log({"level": "INFO", "message": list_output})
 
 
 @click.command(name="list",

--- a/zedenv/cli/set.py
+++ b/zedenv/cli/set.py
@@ -1,29 +1,15 @@
 """Get boot environment properties cli"""
 
-from typing import Optional, List
+from typing import Optional
 
 import click
 
 import pyzfscmds.system.agnostic
 import pyzfscmds.cmd
 
-import zedenv.configuration
 import zedenv.lib.be
 import zedenv.lib.check
 from zedenv.lib.logger import ZELogger
-
-
-def format_get(get_line: list,
-               scripting: Optional[bool],
-               widths: List[int]) -> str:
-    """
-    Formats list into column separated string with tabs if scripting.
-    """
-    if scripting:
-        return "\t".join(get_line)
-    else:
-        fmt_line = ["{{: <{width}}}".format(width=w+1) for w in widths]
-        return " ".join(fmt_line).format(*get_line)
 
 
 def zedenv_get(zedenv_properties: Optional[list],
@@ -55,43 +41,14 @@ def zedenv_get(zedenv_properties: Optional[list],
         }, exit_on_error=True)
 
     prop_list = props.splitlines()
-    prop_output = []
 
     if not scripting:
-        prop_output.append(prop_list[0].split())
+        ZELogger.log({"level": "INFO", "message": prop_list[0]})
 
-    prop_list_props = []
-    for pr in prop_list:
-        split_prop = pr.split()
+    for p in prop_list:
+        split_prop = p.split()
         if split_prop[property_index].startswith("org.zedenv"):
-            prop_list_props.append(split_prop)
-
-    prop_output.extend(prop_list_props)
-
-    if not recursive:
-        props_unset = []
-        only_props = [j[property_index] for j in prop_list_props]
-        for cfg in zedenv.configuration.allowed_properties:
-            if f'org.zedenv:{cfg["property"]}' not in only_props:
-                props_unset.append(
-                    [f'org.zedenv:{cfg["property"]}', f'default ({cfg["default"]})'])
-
-        prop_output.extend(props_unset)
-
-    # Set minimum column width to name of column plus one
-    widths = [len(l) + 1 for l in columns]
-
-    # Check for largest column entry and use as width.
-    for upe in prop_output:
-        for i, w in enumerate(upe):
-            if len(w) > widths[i]:
-                widths[i] = len(w)
-
-    formatted_list_entries = [format_get(b, scripting, widths)
-                              for b in prop_output]
-
-    for k in formatted_list_entries:
-        ZELogger.log({"level": "INFO", "message": k})
+            ZELogger.log({"level": "INFO", "message": p})
 
 
 @click.command(name="get",

--- a/zedenv/cli/set.py
+++ b/zedenv/cli/set.py
@@ -12,64 +12,36 @@ import zedenv.lib.check
 from zedenv.lib.logger import ZELogger
 
 
-def zedenv_get(zedenv_properties: Optional[list],
-               scripting: Optional[bool],
-               recursive: Optional[bool],
-               be_root: str):
+def zedenv_set(verbose: Optional[bool], zedenv_properties: Optional[list], be_root: str):
 
-    property_index = 0
-    columns = ["property", "value"]
+    for prop in zedenv_properties:
+        try:
+            pyzfscmds.cmd.zfs_set(be_root, prop)
+        except RuntimeError:
+            ZELogger.log({
+                "level": "EXCEPTION",
+                "message": f"Failed to set zedenv property '{prop}'\n"
+            }, exit_on_error=True)
 
-    zedenv_props = zedenv_properties if zedenv_properties else ["all"]
-
-    if recursive:
-        property_index = property_index + 1
-        columns.insert(0, "name")
-
-    props = None
-    try:
-        props = pyzfscmds.cmd.zfs_get(be_root,
-                                      properties=zedenv_props,
-                                      scripting=scripting,
-                                      recursive=recursive,
-                                      columns=columns,
-                                      zfs_types=['filesystem'])
-    except RuntimeError as err:
-        ZELogger.log({
-            "level": "EXCEPTION",
-            "message": f"Failed to get zedenv properties\n{err}\n"
-        }, exit_on_error=True)
-
-    prop_list = props.splitlines()
-
-    if not scripting:
-        ZELogger.log({"level": "INFO", "message": prop_list[0]})
-
-    for p in prop_list:
-        split_prop = p.split()
-        if split_prop[property_index].startswith("org.zedenv"):
-            ZELogger.log({"level": "INFO", "message": p})
+        if verbose:
+            ZELogger.verbose_log({
+                "level": "INFO",
+                "message": f"Set '{prop}' successfully"
+            }, verbose)
 
 
-@click.command(name="get",
-               help="Get all boot environment properties that are set.")
-@click.option('--recursive', '-r',
+@click.command(name="set",
+               help="Set boot environment properties.")
+@click.option('--verbose', '-v',
               is_flag=True,
-              help="Recursively get all zedenv properties from all datasets under ROOT.")
-@click.option('--scripting', '-H',
-              is_flag=True,
-              help="Scripting output.")
-@click.argument('zedenv_properties', nargs=-1, required=False)
-def cli(zedenv_properties: Optional[list],
-        scripting: Optional[bool],
-        recursive: Optional[bool]):
+              help="Print verbose output.")
+@click.argument('zedenv_properties', nargs=-1, required=True)
+def cli(verbose: Optional[bool],
+        zedenv_properties: Optional[list]):
 
     try:
         zedenv.lib.check.startup_check()
     except RuntimeError as err:
         ZELogger.log({"level": "EXCEPTION", "message": err}, exit_on_error=True)
 
-    zedenv_get(zedenv_properties,
-               scripting,
-               recursive,
-               zedenv.lib.be.root())
+    zedenv_set(verbose, zedenv_properties, zedenv.lib.be.root())

--- a/zedenv/configuration.py
+++ b/zedenv/configuration.py
@@ -1,0 +1,5 @@
+from typing import Tuple
+
+allowed_properties: Tuple[dict] = (
+    {"property": 'bootloader', "description": "Set a bootloader plugin.", "default": None},
+)

--- a/zedenv/configuration.py
+++ b/zedenv/configuration.py
@@ -1,5 +1,5 @@
 from typing import Tuple
 
 allowed_properties: Tuple[dict] = (
-    {"property": 'bootloader', "description": "Set a bootloader plugin.", "default": None},
+    {"property": 'bootloader', "description": "Set a bootloader plugin.", "default": ""},
 )

--- a/zedenv/lib/configure.py
+++ b/zedenv/lib/configure.py
@@ -17,6 +17,20 @@ def get_plugins():
     return plugins
 
 
+def get_bootloader_properties():
+    plugins = get_plugins()
+    plugin_list = []
+
+    for p in plugins:
+        if platform.system().lower() in plugins[p].systems_allowed:
+            plugin_list.append({
+                "bootloader": plugins[p].bootloader,
+                "properties": plugins[p].allowed_properties
+            })
+
+    return plugin_list
+
+
 def get_bootloader(boot_environment: str,
                    old_boot_environment: str,
                    bootloader: str,

--- a/zedenv/plugins/configuration.py
+++ b/zedenv/plugins/configuration.py
@@ -1,8 +1,7 @@
-import shutil
+import click
 import os
 import re
-
-import click
+import shutil
 import zedenv.lib.be
 from zedenv.lib.logger import ZELogger
 
@@ -56,8 +55,8 @@ class Plugin(object):
                 "message": f"Checking prop: 'org.zedenv.{self.bootloader}:{prop}'"
             }, self.verbose)
             prop_val = zedenv.lib.be.get_property(
-                    "/".join([self.be_root, self.boot_environment]),
-                    f"org.zedenv.{self.bootloader}:{prop}")
+                "/".join([self.be_root, self.boot_environment]),
+                f"org.zedenv.{self.bootloader}:{prop}")
 
             if prop_val is not None and prop_val != "-":
                 self.zedenv_properties[prop] = prop_val

--- a/zedenv/plugins/freebsdloader.py
+++ b/zedenv/plugins/freebsdloader.py
@@ -13,6 +13,8 @@ class FreeBSDLoader(plugin_config.Plugin):
     systems_allowed = ["freebsd"]
     bootloader = "freebsdloader"
 
+    allowed_properties: tuple = ()
+
     def __init__(self, zedenv_data: dict):
 
         super().__init__(zedenv_data)


### PR DESCRIPTION
# Add 'get' and 'set' commands

This PR adds 'get' and 'set' commands.

## zedenv get

Example showing currently set properties:

```
$ zedenv get

PROPERTY                   VALUE
org.zedenv.grub:bootonzfs  yes
org.zedenv:bootloader      systemdboot
org.zedenv.grub:boot       /mnt/efi
```

Show 'defaults' with properties used if unset.

```
$ zedenv get --defaults

PROPERTY                    DEFAULT    DESCRIPTION
org.zedenv:bootloader                  Set a bootloader plugin.
org.zedenv.systemdboot:esp  /mnt/efi   Set location for esp.
org.zedenv.grub:boot        /mnt/boot  Set location for boot.
org.zedenv.grub:bootonzfs   no         Use ZFS for /boot.
```

Flags:

`--scripting/-H` - Removes headers and uses tabs as delimiter.
`--recursive/-r` - Gets props from all datasets under the BE ROOT.
`--defaults/-D` - Show default settings only.

---

## zedenv set

Add set command

```
$ zedenv set -v org.zedenv:bootloader=systemdboot \
                org.zedenv.grub:bootonzfs=no
Set 'org.zedenv:bootloader=systemdboot' successfully
Set 'org.zedenv.grub:bootonzfs=no' successfully
```